### PR TITLE
fix: Missing schema properties

### DIFF
--- a/tap_spotify/schemas/album.py
+++ b/tap_spotify/schemas/album.py
@@ -15,6 +15,7 @@ AlbumObject = th.PropertiesList(
     th.Property("href", th.StringType),
     th.Property("id", th.StringType),
     th.Property("images", th.ArrayType(ImageObject)),
+    th.Property("is_playable", th.BooleanType),
     th.Property("name", th.StringType),
     th.Property("release_date", th.StringType),
     th.Property("release_date_precision", th.StringType),

--- a/tap_spotify/schemas/track.py
+++ b/tap_spotify/schemas/track.py
@@ -29,3 +29,9 @@ TrackObject = th.PropertiesList(
     th.Property("type", th.StringType),
     th.Property("uri", th.StringType),
 )
+
+PlaylistTrackObject = th.PropertiesList(
+    *TrackObject,
+    th.Property("episode", th.BooleanType),
+    th.Property("track", th.BooleanType),
+)

--- a/tap_spotify/streams.py
+++ b/tap_spotify/streams.py
@@ -12,7 +12,7 @@ from typing_extensions import override
 from tap_spotify.client import SpotifyStream
 from tap_spotify.schemas.artist import ArtistObject
 from tap_spotify.schemas.audio_features import AudioFeaturesObject
-from tap_spotify.schemas.track import TrackObject
+from tap_spotify.schemas.track import PlaylistTrackObject, TrackObject
 from tap_spotify.schemas.utils.rank import Rank
 from tap_spotify.schemas.utils.synced_at import SyncedAt
 
@@ -197,7 +197,7 @@ class _PlaylistTracksStream(_RankStream, _SyncedAtStream, _TracksStream):
 
     records_jsonpath = "$.tracks.items[*].track"
     schema = th.PropertiesList(
-        *TrackObject,
+        *PlaylistTrackObject,
         *AudioFeaturesObject,
         *Rank,
         *SyncedAt,


### PR DESCRIPTION
Addresses
```
2024-10-15 15:37:44,845 | WARNING  | tap-spotify.user_saved_tracks_stream | Properties ('album.is_playable',) were present in the 'user_saved_tracks_stream' stream but not found in catalog schema. Ignoring.
```
and similar warnings.